### PR TITLE
perf: use optimized stylesheet for configurator styles, icons and fonts

### DIFF
--- a/configurator-webcomponents/api/index.html
+++ b/configurator-webcomponents/api/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html style="height: 100%">
     <head>
-        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-        <link href="https://storage.googleapis.com/cm-platform-prod-static/fonts/fontawesome-pro-6.0.0-alpha3/css/all.css" rel="stylesheet" />
-        <link href="https://fonts.googleapis.com/css?family=Roboto:200,300,400,500,600,700" rel="stylesheet" />
+        <link rel="preconnect" href="https://configurator.colormass.com" />
+        <link href="https://configurator.colormass.com/styles.css" rel="stylesheet" />
         <script src="https://configurator.colormass.com/cm-configurator.js" type="module"></script>
+        
         <link rel="stylesheet" href="../styles/sample.css" />
         <link rel="stylesheet" href="../styles/ui.css" />
+        
         <title>Configurator Web Component Example</title>
         <meta charset="UTF-8" />
     </head>

--- a/configurator-webcomponents/custom-menu/index.html
+++ b/configurator-webcomponents/custom-menu/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html style="height: 100%">
     <head>
-        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-        <link href="https://storage.googleapis.com/cm-platform-prod-static/fonts/fontawesome-pro-6.0.0-alpha3/css/all.css" rel="stylesheet" />
-        <link href="https://fonts.googleapis.com/css?family=Roboto:200,300,400,500,600,700" rel="stylesheet" />
-
+        <link rel="preconnect" href="https://configurator.colormass.com" />
+        <!-- Load the colormass configurator styles -->
+        <link href="https://configurator.colormass.com/styles.css" rel="stylesheet" />
         <!-- Load the colormass configurator web components -->
         <script src="https://configurator.colormass.com/cm-configurator.js" type="module"></script>
 

--- a/configurator-webcomponents/overlay-material-color/index.html
+++ b/configurator-webcomponents/overlay-material-color/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html style="height: 100%">
     <head>
-        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-        <link href="https://storage.googleapis.com/cm-platform-prod-static/fonts/fontawesome-pro-6.0.0-alpha3/css/all.css" rel="stylesheet" />
-        <link href="https://fonts.googleapis.com/css?family=Roboto:200,300,400,500,600,700" rel="stylesheet" />
-
+        <link rel="preconnect" href="https://configurator.colormass.com" />
+        <!-- Load the colormass configurator styles -->
+        <link href="https://configurator.colormass.com/styles.css" rel="stylesheet" />
         <!-- Load the colormass configurator web components -->
         <script src="https://configurator.colormass.com/cm-configurator.js" type="module"></script>
 

--- a/configurator-webcomponents/set-material-by-color-overlay/index.html
+++ b/configurator-webcomponents/set-material-by-color-overlay/index.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html style="height: 100%">
     <head>
-        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-        <link href="https://storage.googleapis.com/cm-platform-prod-static/fonts/fontawesome-pro-6.0.0-alpha3/css/all.css" rel="stylesheet" />
-        <link href="https://fonts.googleapis.com/css?family=Roboto:200,300,400,500,600,700" rel="stylesheet" />
+        <link rel="preconnect" href="https://configurator.colormass.com" />
+        <link href="https://configurator.colormass.com/styles.css" rel="stylesheet" />
+        <script src="https://configurator.colormass.com/cm-configurator.js" type="module"></script>
+
         <link rel="stylesheet" href="../styles/sample.css" />
         <link rel="stylesheet" href="../styles/ui.css" />
-
-        <script src="https://configurator.colormass.com/cm-configurator.js" type="module"></script>
 
         <title>Custom Menu | Example</title>
         <meta charset="UTF-8" />

--- a/configurator-webcomponents/set-material-by-id/index.html
+++ b/configurator-webcomponents/set-material-by-id/index.html
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html style="height: 100%">
     <head>
-        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-        <link href="https://storage.googleapis.com/cm-platform-prod-static/fonts/fontawesome-pro-6.0.0-alpha3/css/all.css" rel="stylesheet" />
-        <link href="https://fonts.googleapis.com/css?family=Roboto:200,300,400,500,600,700" rel="stylesheet" />
+        <link rel="preconnect" href="https://configurator.colormass.com" />
+        <link href="https://configurator.colormass.com/styles.css" rel="stylesheet" />
+        <script src="https://configurator.colormass.com/cm-configurator.js" type="module"></script>
+
         <link rel="stylesheet" href="../styles/sample.css" />
         <link rel="stylesheet" href="../styles/ui.css" />
-
-        <script src="https://configurator.colormass.com/cm-configurator.js" type="module"></script>
 
         <title>Custom Menu | Example</title>
         <meta charset="UTF-8" />

--- a/configurator-webcomponents/styled menu/index.html
+++ b/configurator-webcomponents/styled menu/index.html
@@ -1,10 +1,9 @@
 <!DOCTYPE html>
 <html style="height: 100%">
     <head>
-        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-        <link href="https://storage.googleapis.com/cm-platform-prod-static/fonts/fontawesome-pro-6.0.0-alpha3/css/all.css" rel="stylesheet" />
-        <link href="https://fonts.googleapis.com/css?family=Roboto:200,300,400,500,600,700" rel="stylesheet" />
-
+        <link rel="preconnect" href="https://configurator.colormass.com" />
+        <!-- Load the colormass configurator styles -->
+        <link href="https://configurator.colormass.com/styles.css" rel="stylesheet" />
         <!-- Load the colormass configurator web components -->
         <script src="https://configurator.colormass.com/cm-configurator.js" type="module"></script>
 


### PR DESCRIPTION
### Changes

Instead of loading all font-awesome and material icons, we can now fetch the optimized `styles.css` which contains only what we actually need for the configurator.